### PR TITLE
Refactor sparse pattern models using the segment_sum

### DIFF
--- a/jaxchem/models/gcn/pad_pattern/gcn_layer.py
+++ b/jaxchem/models/gcn/pad_pattern/gcn_layer.py
@@ -75,7 +75,7 @@ class PadGCNLayer(hk.Module):
         dropout = self.dropout if is_training is True else 0.0
 
         # for batch data
-        new_node_feats = jax.vmap(self.__update_func)(node_feats, adj)
+        new_node_feats = jax.vmap(self._update_nodes)(node_feats, adj)
         if self.bias:
             new_node_feats += self.b
         new_node_feats = self.activation(new_node_feats)
@@ -87,7 +87,7 @@ class PadGCNLayer(hk.Module):
 
         return new_node_feats
 
-    def __update_func(self, node_feats: jnp.ndarray, adj: jnp.ndarray) -> jnp.ndarray:
+    def _update_nodes(self, node_feats: jnp.ndarray, adj: jnp.ndarray) -> jnp.ndarray:
         """Function of updating node features with no batch data.
 
         The case adjacency matrix is normalized,


### PR DESCRIPTION
I refactor sparse pattern models using the segment_sum, but this refactoring didn't fix the performnace issue.
This is because `jax.ops.segment_sum` also use `jax.ops.index_add` internally.... 

This PR didn't fix the performance issue, but I want to merge because `jax.ops.segment_sum` is better than using  `jax.ops.index_add` directly.

Next, I will try to make the new graph dataset class related to https://github.com/deepchem/deepchem/issues/1942 until Nathan finish working the crystal dataset support.